### PR TITLE
Fixed metadata extraction issues

### DIFF
--- a/RAD.podspec
+++ b/RAD.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source_files  = "RAD/**/*.{h,m,swift}"
   s.resource      = "RAD/Model/RADDatabaseModel.xcdatamodeld"
   s.frameworks    = "Foundation", "AVFoundation", "CoreMedia", "CoreData"
-  s.dependency "ReachabilitySwift"
+  s.dependency "ReachabilitySwift", "~> 4.3"
   s.swift_version = "4.2"
 end

--- a/RAD/Model/Operations/JsonProcessing/ParseRADPayloadOperation.swift
+++ b/RAD/Model/Operations/JsonProcessing/ParseRADPayloadOperation.swift
@@ -31,8 +31,8 @@ class ParseRADPayloadOperation: OutputOperation<String> {
             asset.availableMetadataFormats.reduce([:], { result, format in
                 var new = result
                 let formatMetadata = asset.metadata(forFormat: format)
-                formatMetadata.forEach({
-                    new[format.rawValue] = $0.stringValue
+                formatMetadata.enumerated().forEach({
+                    new[String($0.offset)] = $0.element.stringValue
                 })
                 return new
             })


### PR DESCRIPTION
The current implementation for data extraction from audio assets is not able to properly extract metadata from id3 tags as it currently only works if the RAD metadata is added as the last element in a file.

I modified the logic to make sure all metadata items are properly extracted, regardless of position in the set of tags.